### PR TITLE
fix: unexpected error: pkg[action].some is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class DynamicGroupPlugin {
       }
 
       // Direct group access.
-      const hasPermission = pkg[action].some(group => userName === group || userGroups.includes(group));
+      const hasPermission = (pkg[action] || []).some(group => userName === group || userGroups.includes(group));
       if (hasPermission) {
         return callback(null, true);
       }


### PR DESCRIPTION
this fix #1, as verdaccio docs said
| [If you want to block the access/publish to a specific group of packages. Just do not define access and publish.](https://verdaccio.org/docs/packages/#blocking-access-to-set-of-packages)

when package access is left not defined, `pkg[action]` value is undefined